### PR TITLE
chore: fix github repo path in readme (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository contains TypeScript implementations for interacting with Solayer
 Clone this repository and install the dependencies:
 
 ```
-git clone git@github.com:solayer-labs/create-avs.git
-cd create-avs
+git clone git@github.com:solayer-labs/solayer-cli.git
+cd solayer-cli
 yarn install
 ```
 


### PR DESCRIPTION
`create-avs` has been renamed to `solayer-cli`. As such, updating the readme to reflect it 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions in the README to reflect the new repository URL and navigation commands for better clarity and user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->