### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Accounts: The restake function interacts with various accounts:
 - Parameters:
   - amount (u64): The amount of LST tokens to restake.
 
-Under the hood, calling the restake function will:
+Under the hood, calling the unrestake function will:
 
 1. Check if the Solayer signer is a co-signer of the transaction
 2. Unlocks the restaking account


### PR DESCRIPTION
The section describes the unrestaking process and its implementation details. The current text incorrectly refers to the "restake function" when it should be "unrestake function". This correction improves documentation accuracy and prevents potential confusion for developers implementing the unrestaking functionality.