### PR TITLE
**Fix Typo in `unrestake_ssol.ts`**

### DIFF
--- a/restaking/actions/unrestake_ssol.ts
+++ b/restaking/actions/unrestake_ssol.ts
@@ -54,7 +54,7 @@ export async function unrestake(
         RESTAKING_PROGRAM_ID
     );
 
-    // Define the accounts and derive the associated token account (ATA) addressses to call the unrestake method
+    // Define the accounts and derive the associated token account (ATA) addresses to call the unrestake method
     // POOL_ADDRESS:    3sk58CzpitB9jsnVzZWwqeCn2zcXVherhALBh88Uw9GQ
     // SSOL_MINT:       sSo14endRuUbvQaJS3dq36Q829a3A6BEfoeeRGJywEh
     // STAKE_POOL_MINT: sSo1wxKKr6zW2hqf5hZrp2CawLibcwi1pMBqk5bg2G4


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `unrestake_ssol.ts`**

## Description  
This pull request addresses a minor typo in the `unrestake_ssol.ts` file. Specifically, "addressses" was corrected to "addresses" for accuracy and better readability.

### Changes Made:
- **File Modified:** `restaking/actions/unrestake_ssol.ts`
- **Summary of Changes:**  
  - Fixed the spelling of "addressses" to "addresses."

## Checklist  
- [x] Corrected typographical error to enhance clarity.
- [x] Verified that no functional changes were introduced.

## Additional Notes  
This change is editorial and does not affect the code's execution or functionality.

---

**Allow edits by maintainers:** [x]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected spelling of "addresses" in a comment within the unrestake function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->