### PR TITLE
Update error handling in solana-config.ts

### DIFF
--- a/utils/solana-config.ts
+++ b/utils/solana-config.ts
@@ -1,5 +1,13 @@
 import { execSync } from "child_process";
 
+interface ExecError extends Error {
+  stderr?: Buffer;
+}
+
+function isExecError(error: Error): error is ExecError {
+  return "stderr" in error;
+}
+
 const checkSolanaConfig = () => {
   let rpcUrl = "https://api.mainnet-beta.solana.com";
   let keypairPath = "~/.config/solana/id.json";
@@ -20,10 +28,8 @@ const checkSolanaConfig = () => {
     }
   } catch (error: unknown) {
     let errorMessage: string;
-    if (error instanceof Error) {
-      const stderrOutput = (error as any).stderr
-        ? (error as any).stderr.toString()
-        : "";
+    if (error instanceof Error && isExecError(error)) {
+      const stderrOutput = error.stderr?.toString() ?? "";
       errorMessage = stderrOutput
         ? `${error.message}\nStderr: ${stderrOutput}`
         : error.message;

--- a/utils/solana-config.ts
+++ b/utils/solana-config.ts
@@ -18,8 +18,22 @@ const checkSolanaConfig = () => {
     if (keypairPathMatch) {
       keypairPath = keypairPathMatch[1].trim();
     }
-  } catch (error) {
-    throw new Error(`Failed to retrieve Solana configuration: ${error.message}`);
+  } catch (error: unknown) {
+    let errorMessage: string;
+    if (error instanceof Error) {
+      const stderrOutput = (error as any).stderr
+        ? (error as any).stderr.toString()
+        : "";
+      errorMessage = stderrOutput
+        ? `${error.message}\nStderr: ${stderrOutput}`
+        : error.message;
+    } else {
+      errorMessage = String(error);
+    }
+    throw new Error(
+      `Failed to retrieve Solana configuration: ${errorMessage}`,
+      { cause: error }
+    );
   }
   return { rpcUrl, keypairPath };
 };


### PR DESCRIPTION
+ In the catch block, I checked if the caught error is an instance of Error and then I looked for an `stderr` property IF there is any.
+ I included both the error message and any stderr output in the final error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced error handling during configuration retrieval to deliver clearer, more detailed error messages with improved context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->